### PR TITLE
Updated to newest Home Assistant version

### DIFF
--- a/cross/homeassistant/Makefile
+++ b/cross/homeassistant/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME = homeassistant
 PKG_EXT = tar.gz
 PKG_DOWNLOAD_METHOD = git
-PKG_GIT_HASH = d9e3c02df3a2690e74d1b606e8db0a4dd686e872
+PKG_GIT_HASH = 785e5e0fe7b1989b5a8cb9c1622738d3e555442d
 PKG_DIST_SITE = https://github.com/balloob/home-assistant.git
 PKG_DIST_FILE = $(PKG_NAME)-git$(PKG_GIT_HASH).$(PKG_EXT)
 PKG_DIR = $(PKG_NAME)-git$(PKG_GIT_HASH)
@@ -9,7 +9,7 @@ PKG_DIR = $(PKG_NAME)-git$(PKG_GIT_HASH)
 DEPENDS =
 
 HOMEPAGE = https://home-assistant.io/
-COMMENT  = 
+COMMENT  =
 LICENSE  = MIT
 
 CONFIGURE_TARGET = nop

--- a/spk/homeassistant/Makefile
+++ b/spk/homeassistant/Makefile
@@ -20,7 +20,7 @@ DISPLAY_NAME = Home Assistant
 DSM_UI_DIR = app
 
 BETA = 1
-CHANGELOG = "Update to revision d9e3c02df3a2690e74d1b606e8db0a4dd686e872. Chromecast works now. Other dependencies are also added"
+CHANGELOG = "Update to revision 785e5e0fe7b1989b5a8cb9c1622738d3e555442d. PyISY will now work without having the climate module installed."
 
 HOMEPAGE   = https://home-assistant.io/
 LICENSE    = MIT

--- a/spk/homeassistant/src/requirements.txt
+++ b/spk/homeassistant/src/requirements.txt
@@ -47,7 +47,7 @@ python-nest>=2.3.1
 pydispatcher>=2.0.5
 
 # ISY994 bindings (*.isy994)
-PyISY>=1.0.2
+PyISY>=1.0.5
 
 # PSutil (sensor.systemmonitor)
 psutil>=2.2.1


### PR DESCRIPTION
Updated to newest Home Assistant version for better ISY994 support. This is a quick fix to address [Home Assistant issue #201](https://github.com/balloob/home-assistant/issues/201). A full fix is coming with the next push from dev to master.

Note: I don't have a device to test this PR on. Please verify it installs correctly.